### PR TITLE
Added `has_many` associations

### DIFF
--- a/lib/beloved.rb
+++ b/lib/beloved.rb
@@ -34,4 +34,4 @@ module Beloved
   end
 end
 
-Dir[File.expand_path "lib/beloved/**/*.rb"].each{ |f| require_relative f }
+Dir[File.expand_path "lib/beloved/services/**/*.rb"].each{ |f| require_relative f }

--- a/lib/beloved/peace/modules/association.rb
+++ b/lib/beloved/peace/modules/association.rb
@@ -8,6 +8,15 @@ module Peace::Association
 
   def has_many(sym, mapping)
     @@has_many << sym
+
+    define_method sym, lambda {
+      modpath     = self.class.to_s.split('::')
+      modpath[-1] = sym.to_s.classify # Inject :sym classname
+      klass       = modpath.join('::').constantize
+      hash        = mapping.inject({}){ |map, (k,v)| map.merge({"#{k}": self.send(v)}) }
+
+      klass.all(hash)
+    }
   end
 
   def api_requires(*args)

--- a/spec/beloved/services/compute/models/server_spec.rb
+++ b/spec/beloved/services/compute/models/server_spec.rb
@@ -15,4 +15,8 @@ describe Beloved::Compute::Server do
     expect(servers.count > 0).to be_truthy
   end
 
+  it 'knows how to get nested resources' do
+    expect(server.volumes).to eq([])
+  end
+
 end


### PR DESCRIPTION
``` ruby
module Beloved::Compute::Server
  has_many :volumes, {server_id: :id}
end
```

This tells the `Server` class that it has nested `Volume` and that in order to look it up we need to match up the `server_id` attribute in `Volume` to `id` in `Server`.

We can now do things like `Beloved::Compute::Server.first.volumes`.